### PR TITLE
Fix 537

### DIFF
--- a/hifive/src/main/webapp/src/h5.validation.js
+++ b/hifive/src/main/webapp/src/h5.validation.js
@@ -1057,10 +1057,11 @@
 		 */
 		removeRule: function(keys) {
 			if (!isArray(keys)) {
-				delete this._rule[keys];
-			}
-			for (var i = 0, l = keys.length; i < l; i++) {
-				delete this._rule[keys[i]];
+				this._rule[keys] = {};
+			} else {
+				for (var i = 0, l = keys.length; i < l; i++) {
+					this._rule[keys[i]] = {};
+				}
 			}
 		},
 

--- a/hifive/src/main/webapp/test/h5.ui.FormController.js
+++ b/hifive/src/main/webapp/test/h5.ui.FormController.js
@@ -177,6 +177,49 @@ $(function() {
 		ok(result.isValid, 'プロパティを配列で複数指定した場合は複数プロパティのルールを削除できること');
 	});
 
+	test('指定したプロパティのルールが削除されて、ルールのプロパティを持っていないこと', function() {
+		var formCtrl = this.formController;
+		formCtrl.removeRule('a');
+		formCtrl.validate();
+		var propRule;
+		propRule = formCtrl._validationLogic._rule['a'];
+		ok(!propRule.hasOwnProperty('required'), 'プロパティはルールのプロパティを持っていないこと');
+		propRule = formCtrl._validationLogic._rule['b'];
+		ok(!propRule.hasOwnProperty('required'), 'プロパティはルールのプロパティを持っていないこと');
+	});
+
+	test('指定していないプロパティのルールが削除されていないで、ルーツのプロパティを持っていること', function() {
+		var formCtrl = this.formController;
+		formCtrl.addRule({
+			b: {
+				required: true
+			}
+		});
+		formCtrl.removeRule('a');
+		formCtrl.validate();
+		var propRule;
+		propRule = formCtrl._validationLogic._rule['a'];
+		ok(!propRule.hasOwnProperty('required'), 'プロパティはルールのプロパティを持っていないこと');
+		propRule = formCtrl._validationLogic._rule['b'];
+		ok(propRule.hasOwnProperty('required'), 'プロパティはルールのプロパティを持っていること');
+	});
+
+	test('プロパティを配列で複数指定した場合は複数プロパティのルールを削除できるて、ルールプロパティを持っていないこと', function() {
+		var formCtrl = this.formController;
+		formCtrl.addRule({
+			b: {
+				required: true
+			}
+		});
+		formCtrl.removeRule(['a', 'b']);
+		formCtrl.validate();
+		var propRule;
+		propRule = formCtrl._validationLogic._rule['a'];
+		ok(!propRule.hasOwnProperty('required'), 'プロパティはルールのプロパティを持っていないこと');
+		propRule = formCtrl._validationLogic._rule['b'];
+		ok(!propRule.hasOwnProperty('required'), 'プロパティはルールのプロパティを持っていないこと');
+	});
+
 	//=============================
 	// Definition
 	//=============================


### PR DESCRIPTION
#537 FormController#removeRule()でルール自体を削除せず、ルールを空にするように修正
#537 FormController#removeRule()でルールを削除するとルールが空になることを確認するテストケースを追加