### PR TITLE
Fix 557

### DIFF
--- a/hifive/src/main/webapp/src/h5.validation.js
+++ b/hifive/src/main/webapp/src/h5.validation.js
@@ -682,10 +682,28 @@
 		 * </p>
 		 *
 		 * @param {Any} value 判定する値
+		 * @param {Any} param 入力値と比較したい時刻
 		 * @returns {boolean}
 		 */
-		future: function(value) {
-			return value == null || value instanceof Date && new Date().getTime() < value.getTime();
+		future: function(value, param) {
+			var target = (function() {
+				if (param instanceof Date) {
+					return param;
+				} else if ($.isNumeric(param)) {
+					return new Date(typeof param === "number" ? param : parseInt(param));
+				} else if (param == null) {
+					return new Date();
+				} else if (param === true) {
+					return new Date();
+				}
+
+				var date = Date.parse(param);
+				if (!isNaN(date)) {
+					return new Date(date);
+				}
+				throw new Error('future:Date型に変換できないパラメータが指定されています');
+			})();
+			return value == null || value instanceof Date && target.getTime() < value.getTime();
 		},
 
 		/**
@@ -698,10 +716,28 @@
 		 * </p>
 		 *
 		 * @param {Any} value 判定する値
+		 * @param {Any} param 入力値と比較したい時刻
 		 * @returns {boolean}
 		 */
-		past: function(value) {
-			return value == null || value instanceof Date && value.getTime() < new Date().getTime();
+		past: function(value, param) {
+			var target = (function() {
+				if (param instanceof Date) {
+					return param;
+				} else if ($.isNumeric(param)) {
+					return new Date(typeof param === "number" ? param : parseInt(param));
+				} else if (param == null) {
+					return new Date();
+				} else if (param === true) {
+					return new Date();
+				}
+
+				var date = Date.parse(param);
+				if (!isNaN(date)) {
+					return new Date(date);
+				}
+				throw new Error('past:Date型に変換できないパラメータが指定されています');
+			})();
+			return value == null || value instanceof Date && value.getTime() < target.getTime();
 		},
 
 		/**

--- a/hifive/src/main/webapp/test/h5.validation.js
+++ b/hifive/src/main/webapp/test/h5.validation.js
@@ -322,6 +322,142 @@ $(function() {
 		}).isValid, true, 'undefinedならvalid');
 	});
 
+	test('futureのパラメータを指定できること', function() {
+		var validator = this.validator;
+		var current = new Date();
+		var future = new Date(current.getTime() + 3600000);
+
+		validator.addRule({
+			p1: {
+				future: current.toISOString()
+			}
+		});
+		strictEqual(validator.validate({
+			p1: future
+		}).isValid, true, '現在時刻の文字列型を指定し、入力が未来の時刻ならばtrue');
+
+		validator.addRule({
+			p1: {
+				future: current.getTime()
+			}
+		});
+		strictEqual(validator.validate({
+			p1: future
+		}).isValid, true, '現在時刻のUnixTime数値型を指定し、入力が未来の時刻ならばtrue');
+
+		validator.addRule({
+			p1: {
+				future: current.getTime().toString()
+			}
+		});
+		strictEqual(validator.validate({
+			p1: future
+		}).isValid, true, '現在時刻のUnixTime文字列型を指定し、入力が未来の時刻ならばtrue');
+
+		validator.addRule({
+			p1: {
+				future: current
+			}
+		});
+		strictEqual(validator.validate({
+			p1: future
+		}).isValid, true, '現在時刻のDate型を指定し、入力が未来の時刻ならばtrue');
+
+		validator.addRule({
+			p1: {
+				future: true
+			}
+		});
+		strictEqual(validator.validate({
+			p1: future
+		}).isValid, true, 'trueを指定し、入力が未来の時刻ならばtrue');
+
+		validator.addRule({
+			p1: {
+				future: null
+			}
+		});
+		strictEqual(validator.validate({
+			p1: future
+		}).isValid, true, 'nullを指定する場合、true');
+
+		validator.addRule({
+			p1: {
+				future: undefined
+			}
+		});
+		strictEqual(validator.validate({
+			p1: future
+		}).isValid, true, 'undefinedを指定する場合、true');
+	});
+
+	test('futureのパラメータを指定し、入力が未来の時刻だけtrueになること', function() {
+		var validator = this.validator;
+		var current = new Date();
+		var future = new Date(current.getTime() + 1);
+		var past = new Date(current.getTime() - 1);
+
+		validator.addRule({
+			p1: {
+				future: current.toISOString()
+			}
+		});
+		strictEqual(validator.validate({
+			p1: future
+		}).isValid, true, '現在時刻の文字列型を指定し、入力が未来の時刻ならばtrue');
+		strictEqual(validator.validate({
+			p1: current
+		}).isValid, false, '現在時刻の文字列型を指定し、入力が同じ時刻ならばfalse');
+		strictEqual(validator.validate({
+			p1: past
+		}).isValid, false, '現在時刻の文字列型を指定し、入力が過去の時刻ならばfalse');
+
+		validator.addRule({
+			p1: {
+				future: current.getTime()
+			}
+		});
+		strictEqual(validator.validate({
+			p1: future
+		}).isValid, true, '現在時刻のUnixTime数値型を指定し、入力が未来の時刻ならばtrue');
+		strictEqual(validator.validate({
+			p1: current
+		}).isValid, false, '現在時刻のUnixTime数値型を指定し、入力が同じ時刻ならばfalse');
+		strictEqual(validator.validate({
+			p1: past
+		}).isValid, false, '現在時刻のUnixTime数値型を指定し、入力が過去の時刻ならばfalse');
+
+		validator.addRule({
+			p1: {
+				future: current.getTime().toString()
+			}
+		});
+		strictEqual(validator.validate({
+			p1: future
+		}).isValid, true, '現在時刻のUnixTime文字列型を指定し、入力が未来の時刻ならばtrue');
+		strictEqual(validator.validate({
+			p1: current
+		}).isValid, false, '現在時刻のUnixTime文字列型を指定し、入力が同じ時刻ならばfalse');
+		strictEqual(validator.validate({
+			p1: past
+		}).isValid, false, '現在時刻のUnixTime文字列型を指定し、入力が過去の時刻ならばfalse');
+
+		validator.addRule({
+			p1: {
+				future: current
+			}
+		});
+		strictEqual(validator.validate({
+			p1: future
+		}).isValid, true, '現在時刻のDate型を指定し、入力が未来の時刻ならばtrue');
+		strictEqual(validator.validate({
+			p1: current
+		}).isValid, false, '現在時刻のDate型を指定し、入力が同じ時刻ならばfalse');
+		strictEqual(validator.validate({
+			p1: past
+		}).isValid, false, '現在時刻のDate型を指定し、入力が過去の時刻ならばfalse');
+	});
+
 	test('past', function() {
 		var validator = this.validator;
 		var current = new Date();
@@ -346,6 +482,142 @@ $(function() {
 		strictEqual(validator.validate({
 			p1: undefined
 		}).isValid, true, 'undefinedならvalid');
+	});
+
+	test('pastのパラメータを指定できること', function() {
+		var validator = this.validator;
+		var current = new Date();
+		var past = new Date(current.getTime() - 3600000);
+
+		validator.addRule({
+			p1: {
+				past: current.toISOString()
+			}
+		});
+		strictEqual(validator.validate({
+			p1: past
+		}).isValid, true, '現在時刻の文字列型を指定し、入力が過去の時刻ならばtrue');
+
+		validator.addRule({
+			p1: {
+				past: current.getTime()
+			}
+		});
+		strictEqual(validator.validate({
+			p1: past
+		}).isValid, true, '現在時刻のUnixTime数値型を指定し、入力が過去の時刻ならばtrue');
+
+		validator.addRule({
+			p1: {
+				past: current.getTime().toString(10)
+			}
+		});
+		strictEqual(validator.validate({
+			p1: past
+		}).isValid, true, '現在時刻のUnixTime文字列型を指定し、入力が過去の時刻ならばtrue');
+
+		validator.addRule({
+			p1: {
+				past: current
+			}
+		});
+		strictEqual(validator.validate({
+			p1: past
+		}).isValid, true, '現在時刻のDate型を指定し、入力が過去の時刻ならばtrue');
+
+		validator.addRule({
+			p1: {
+				past: true
+			}
+		});
+		strictEqual(validator.validate({
+			p1: past
+		}).isValid, true, 'trueを指定し、入力が過去の時刻ならばtrue');
+
+		validator.addRule({
+			p1: {
+				past: null
+			}
+		});
+		strictEqual(validator.validate({
+			p1: past
+		}).isValid, true, 'nullを指定する場合、true');
+
+		validator.addRule({
+			p1: {
+				past: undefined
+			}
+		});
+		strictEqual(validator.validate({
+			p1: past
+		}).isValid, true, 'undefinedを指定する場合、true');
+	});
+
+	test('pastのパラメータを指定し、入力が過去の時刻だけtrueになること', function() {
+		var validator = this.validator;
+		var current = new Date();
+		var future = new Date(current.getTime() + 1);
+		var past = new Date(current.getTime() - 1);
+
+		validator.addRule({
+			p1: {
+				past: current.toISOString()
+			}
+		});
+		strictEqual(validator.validate({
+			p1: future
+		}).isValid, false, '現在時刻の文字列型を指定し、入力が未来の時刻ならばfalse');
+		strictEqual(validator.validate({
+			p1: current
+		}).isValid, false, '現在時刻の文字列型を指定し、入力が同じ時刻ならばfalse');
+		strictEqual(validator.validate({
+			p1: past
+		}).isValid, true, '現在時刻の文字列型を指定し、入力が過去の時刻ならばtrue');
+
+		validator.addRule({
+			p1: {
+				past: current.getTime()
+			}
+		});
+		strictEqual(validator.validate({
+			p1: future
+		}).isValid, false, '現在時刻のUnixTime数値型を指定し、入力が未来の時刻ならばfalse');
+		strictEqual(validator.validate({
+			p1: current
+		}).isValid, false, '現在時刻のUnixTime数値型を指定し、入力が同じ時刻ならばfalse');
+		strictEqual(validator.validate({
+			p1: past
+		}).isValid, true, '現在時刻のUnixTime数値型を指定し、入力が過去の時刻ならばtrue');
+
+		validator.addRule({
+			p1: {
+				past: current.getTime().toString()
+			}
+		});
+		strictEqual(validator.validate({
+			p1: future
+		}).isValid, false, '現在時刻のUnixTime文字列型を指定し、入力が未来の時刻ならばfalse');
+		strictEqual(validator.validate({
+			p1: current
+		}).isValid, false, '現在時刻のUnixTime文字列型を指定し、入力が同じ時刻ならばfalse');
+		strictEqual(validator.validate({
+			p1: past
+		}).isValid, true, '現在時刻のUnixTime文字列型を指定し、入力が過去の時刻ならばtrue');
+
+		validator.addRule({
+			p1: {
+				past: current
+			}
+		});
+		strictEqual(validator.validate({
+			p1: future
+		}).isValid, false, '現在時刻のDate型を指定し、入力が未来の時刻ならばfalse');
+		strictEqual(validator.validate({
+			p1: current
+		}).isValid, false, '現在時刻のDate型を指定し、入力が同じ時刻ならばfalse');
+		strictEqual(validator.validate({
+			p1: past
+		}).isValid, true, '現在時刻のDate型を指定し、入力が過去の時刻ならばtrue');
 	});
 
 	test('assertNull', function() {

--- a/hifive/src/main/webapp/test/h5.validation.js
+++ b/hifive/src/main/webapp/test/h5.validation.js
@@ -394,8 +394,9 @@ $(function() {
 	test('futureのパラメータを指定し、入力が未来の時刻だけtrueになること', function() {
 		var validator = this.validator;
 		var current = new Date();
-		var future = new Date(current.getTime() + 1);
-		var past = new Date(current.getTime() - 1);
+		current.setMilliseconds(0);
+		var future = new Date(current.getTime() + 1000);
+		var past = new Date(current.getTime() - 1000);
 
 		validator.addRule({
 			p1: {
@@ -556,8 +557,9 @@ $(function() {
 	test('pastのパラメータを指定し、入力が過去の時刻だけtrueになること', function() {
 		var validator = this.validator;
 		var current = new Date();
-		var future = new Date(current.getTime() + 1);
-		var past = new Date(current.getTime() - 1);
+		current.setMilliseconds(0);
+		var future = new Date(current.getTime() + 1000);
+		var past = new Date(current.getTime() - 1000);
 
 		validator.addRule({
 			p1: {


### PR DESCRIPTION
#557 パラメータに指定した時刻が入力した時刻より過去か未来か判定するルールを追加
#557 future/pastのパラメータを指定できることを確認するテストケースを追加
