### PR TITLE
Fix #593

### DIFF
--- a/hifive/src/main/webapp/src/h5scopedglobals.js
+++ b/hifive/src/main/webapp/src/h5scopedglobals.js
@@ -368,8 +368,17 @@ function getRegex(target) {
  * @param {Array|Any} args 複数の引数があるときは配列で渡します。
  */
 function registerCallbacksSilently(promise, method, args) {
-	if (promise) {
-		promise._h5UnwrappedCall ? promise._h5UnwrappedCall(method, args) : promise[method](args);
+	if (!promise) {
+		return;
+	}
+	if (promise._h5UnwrappedCall) {
+		promise._h5UnwrappedCall(method, args);
+		return;
+	}
+	if (isArray(args)) {
+		promise[method].apply(promise, args);
+	} else {
+		promise[method](args);
 	}
 }
 

--- a/hifive/src/main/webapp/test/h5.ui.js
+++ b/hifive/src/main/webapp/test/h5.ui.js
@@ -1166,6 +1166,17 @@ $(function() {
 		strictEqual(cfhCount, 1, '複数のプロミスを渡したとき、まとめて1回だけcommonFailHandlerが実行されること');
 	});
 
+	test('jQueryのプロミスオブジェクトを指定した場合にインジケータが表示されること', 2, function() {
+		var dfd = $.Deferred();
+		var indicator = h5.ui.indicator(document, {
+			promises: dfd.promise()
+		}).show();
+		strictEqual($(indicator._target).find('.h5-indicator').length, 2, 'インジケータが表示されること');
+
+		dfd.reject();
+		strictEqual($(indicator._target).find('.h5-indicator').length, 0, 'プロミスが解決した時にインジケータが除去されていること');
+	});
+
 	//=============================
 	// Definition
 	//=============================


### PR DESCRIPTION
scopedglobals#registerCallbacksSilently()について、
- args が配列でなければ promise[method](args)を実行
- 配列であればapply() を呼び出す
とするようにした。