### PR TITLE
#603 h5.eventモジュールのエラーコードを正しく採番したものを使用するように修正。

### DIFF
--- a/hifive/src/main/webapp/src/h5.event.js
+++ b/hifive/src/main/webapp/src/h5.event.js
@@ -18,7 +18,9 @@
 (function() {
 	'use strict';
 
-	var ERR_CODE_PROPERTY_NAME_IS_REQUIRED = 90001; //TODO 要エラーコード採番
+	//h5.eventモジュールのエラーコードは19000番台
+	var ERR_CODE_PROPERTY_NAME_IS_REQUIRED = 19001;
+	var ERR_CODE_INVALID_ARGS_ADDEVENTLISTENER = 19002;
 
 	var RootClass = h5.cls.RootClass;
 


### PR DESCRIPTION
また、addEventListener()の引数チェックエラー時の例外で、
エラーコードがundefinedになっていたのでこれも併せて修正した。（テストケース未追加）