### PR TITLE
#621 Firefox67.0でFormControllerを使っているウィンドウにフォーカスをあてたり外したりすると

### DIFF
--- a/hifive/src/main/webapp/src/h5.ui.FormController.js
+++ b/hifive/src/main/webapp/src/h5.ui.FormController.js
@@ -3322,7 +3322,7 @@
 		 * @returns {Boolean}
 		 */
 		_isFormInputElement: function(element) {
-			if (element) {
+			if (element && element.tagName) {
 				var tagName = element.tagName.toLowerCase();
 				if (tagName == 'input' || tagName == 'select' || tagName == 'textarea') {
 					return true;


### PR DESCRIPTION
TypeError: element.tagName is undefinedが開発者ツールのコンソールに記録されるバグを修正。
element.tagNameがundefined（やnull,空文字）でないことのチェックを追加した。